### PR TITLE
Missing comma after start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typedoc": "0.20.34"
   },
  "scripts": {
-   "start": "node start.js"
+   "start": "node start.js",
     "sync-account": "node ./brick-hill/login.js"
   },
   "author": "10allday",


### PR DESCRIPTION
Dockerfile fails to build with this error.

After adding the missing comma, docker is able to build it. Fixed.